### PR TITLE
PG13 has been release, testing is not available anymore

### DIFF
--- a/centos6/Dockerfile
+++ b/centos6/Dockerfile
@@ -10,8 +10,6 @@ RUN set -ex; \
         epel-release \
         https://download.postgresql.org/pub/repos/yum/reporpms/EL-6-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     ; \
-    sed -i '/yum.testing.13/{n;s/^enabled=0/enabled=1/}' /etc/yum.repos.d/pgdg-redhat-all.repo; \
-    sed -i "/yum.testing.13/s/.releasever/$(grep -Po '6.\d+' /etc/redhat-release)/" /etc/yum.repos.d/pgdg-redhat-all.repo; \
     yum -q -y install \
         postgresql13-server postgresql13-contrib \
         postgresql12-server postgresql12-contrib \

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -10,7 +10,6 @@ RUN set -ex; \
         epel-release \
         https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     ; \
-    yum-config-manager --enable pgdg13-updates-testing; \
     yum -q -y install \
         postgresql13-server postgresql13-contrib \
         postgresql12-server postgresql12-contrib \

--- a/centos8/Dockerfile
+++ b/centos8/Dockerfile
@@ -13,7 +13,6 @@ RUN set -ex; \
     ; \
     yum config-manager --set-enabled PowerTools; \
     dnf -qy module disable postgresql; \
-    yum config-manager --enable pgdg13-updates-testing; \
     yum -qy install \
         postgresql13-server postgresql13-contrib \
         postgresql12-server postgresql12-contrib \


### PR DESCRIPTION
Avoids the following error:
+ yum -q -y install postgresql13-server postgresql13-contrib postgresql12-server postgresql12-contrib postgresql11-server postgresql11-contrib postgresql10-server postgresql10-contrib postgresql96-server postgresql96-contrib postgresql95-server postgresql95-contrib
https://download.postgresql.org/pub/repos/yum/testing/13/redhat/rhel-6.10-x86_64/repodata/repomd.xml: [Errno 14] PYCURL ERROR 22 - "The requested URL returned error: 404 Not Found"