### PR TITLE
ajout bats dans toutes les images sauf centos8

### DIFF
--- a/buster/Dockerfile
+++ b/buster/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex; \
     echo "create_main_cluster = false" > /etc/postgresql-common/createcluster.d/no-main-cluster.conf; \
     apt-get update -y; \
     apt-get install -y --no-install-recommends \
+        bats \
         build-essential \
         lsb-release \
         postgresql-13 postgresql-client-13 \

--- a/centos6/Dockerfile
+++ b/centos6/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex; \
 
 RUN set -ex; \
     yum -q -y install \
+        bats \
         cyrus-sasl-md5 \
         http://opensource.wandisco.com/centos/6/git/x86_64/wandisco-git-release-6-1.noarch.rpm \
         make \

--- a/centos7/Dockerfile
+++ b/centos7/Dockerfile
@@ -23,6 +23,7 @@ RUN set -ex; \
 
 RUN set -ex; \
     yum -q -y install \
+        bats \
         cyrus-sasl-md5 \
         git \
         make \

--- a/stretch/Dockerfile
+++ b/stretch/Dockerfile
@@ -9,6 +9,7 @@ RUN set -ex; \
     echo "create_main_cluster = false" > /etc/postgresql-common/createcluster.d/no-main-cluster.conf; \
     apt-get update -y; \
     apt-get install -y --no-install-recommends \
+        bats \
         build-essential \
         lsb-release \
         postgresql-13 postgresql-client-13 \


### PR DESCRIPTION
bats ne semble pas présent de base dans centos8.

A creuser plus tard si besoin de bats pour cette image.