### PR TITLE
Drop using get-pip.py

### DIFF
--- a/centos6/Dockerfile
+++ b/centos6/Dockerfile
@@ -50,7 +50,9 @@ RUN useradd --system testuser
 RUN set -ex; \
     echo /usr/local/lib/python2.6/site-packages >> /usr/lib/python2.6/site-packages/local.pth; \
     echo /usr/local/lib64/python2.6/site-packages >> /usr/lib/python2.6/site-packages/local.pth; \
-    curl -sSL https://bootstrap.pypa.io/pip/2.6/get-pip.py | python2.6 ; \
+    yum -q -y install python-pip ; \
+    pip2 install --ignore-installed https://files.pythonhosted.org/packages/c4/44/e6b8056b6c8f2bfd1445cc9990f478930d8e3459e9dbf5b8e2d2922d64d3/pip-9.0.3.tar.gz ; \
+    pip2 install wheel ; \
     pip2 --version; \
     rm -rf ~/.cache/; \
     yum clean all ; \


### PR DESCRIPTION
Fixes:

    + python2.6
    + curl -sSL https://bootstrap.pypa.io/pip/2.6/get-pip.py
    DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6
    Collecting pip<10
    /tmp/tmpPgTIZA/pip.zip/pip/_vendor/urllib3/util/ssl_.py:339: SNIMissingWarning: An HTTPS request has been made, but the SNI (Subject Name Indication) extension to TLS is not available on this platform. This may cause the server to present an incorrect TLS certificate, which can cause validation failures. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    /tmp/tmpPgTIZA/pip.zip/pip/_vendor/urllib3/util/ssl_.py:137: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. You can upgrade to a newer version of Python to solve this. For more information, see https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
    Could not find a version that satisfies the requirement pip<10 (from versions: )
    No matching distribution found for pip<10